### PR TITLE
fix: use authorize at release time

### DIFF
--- a/release/action.yaml
+++ b/release/action.yaml
@@ -15,6 +15,10 @@ outputs:
 runs:
   using: "composite"
   steps:
+    - name: Authorize
+      uses: open-turo/action-git-auth@v1
+      with:
+        token: ${{ inputs.github-token }}
     - uses: go-semantic-release/action@v1
       id: release
       with:


### PR DESCRIPTION
This change motivated by the release failure experienced in `turo/cli` GitHub repository yesterday.