### PR TITLE
fix: remove go-version input from release

### DIFF
--- a/release/README.md
+++ b/release/README.md
@@ -32,7 +32,6 @@ If you are using this action for protected branches, replace `GITHUB_TOKEN` with
 | ------------- | ------------------------------------------------------------------------------------------------------------------------------ | -------- | ------- |
 | checkout-repo | Perform checkout as first step of action                                                                                       | `false`  | true    |
 | github-token  | GitHub token that can checkout the consumer repository as well as create tags/releases against it. e.g. 'secrets.GITHUB_TOKEN' | `true`   |         |
-| go-version    | Go version to use for building                                                                                                 | `true`   | 1.17.3  |
 
 ## Outputs
 

--- a/release/action.yaml
+++ b/release/action.yaml
@@ -8,10 +8,6 @@ inputs:
   github-token:
     description: GitHub token that can checkout the consumer repository as well as create tags/releases against it. e.g. 'secrets.GITHUB_TOKEN'
     required: true
-  go-version:
-    description: Go version to use for building
-    required: true
-    default: 1.17.3
 outputs:
   version:
     description: Version of the project
@@ -41,11 +37,14 @@ runs:
       run: |
         git fetch --tags
         git clean -fd
+    - name: Set Go Version
+      shell: bash
+      run: |
+        echo "GOVERSION=$(< .go-version tr -d '\n')" >> $GITHUB_ENV
     - name: Goreleaser
       uses: goreleaser/goreleaser-action@v2
       env:
         GITHUB_TOKEN: ${{ inputs.github-token }}
         GOPRIVATE: github.com/turo/
-        GOVERSION: ${{ inputs.go-version }}
       with:
         args: release


### PR DESCRIPTION
Removes the need for a specific go-version input for the release action. Previously the go-version needed to be specified in the version file as well as the action input. This change removes the duplicate step and just uses the go version specified in the file.