### PR TITLE
feat: tear down volume to avoid flaky integration test result

### DIFF
--- a/integration-test/action.yaml
+++ b/integration-test/action.yaml
@@ -32,11 +32,12 @@ runs:
         DOCKER_BUILDKIT: "1"
         GITHUB_TOKEN: ${{ inputs.github-token }}
       run: |
-        docker-compose -f ${{ inputs.docker-compose-file }} up --build --exit-code-from test ${{ inputs.full-compose-output == 'false' && 'test' || '' }}
+        docker compose down -v -f ${{ inputs.docker-compose-file }} \
+        && docker compose -f ${{ inputs.docker-compose-file }} up --build --exit-code-from test ${{ inputs.full-compose-output == 'false' && 'test' || '' }}
         echo '::set-output name=docker_up::true'
     - name: Cleanup
       if: ${{ steps.build.outputs.docker_up }}
       shell: bash
       env:
         DOCKER_BUILDKIT: "1"
-      run: docker-compose down
+      run: docker compose down -v -f ${{ inputs.docker-compose-file }}


### PR DESCRIPTION
# Summary
I ran into flaky integration test in [#40](https://github.com/turo/schema-migration/pull/40) and by [manually the CI to tear down docker volume](https://github.com/turo/schema-migration/pull/40/files#r1434403012) resolved the issue. Hence I'm opening a PR in this repo to fix this issue.

This PR make sure that we tear down the volume to prevent unintended database reuse.