### PR TITLE
fix: docker compose down

### DIFF
--- a/integration-test/action.yaml
+++ b/integration-test/action.yaml
@@ -32,7 +32,7 @@ runs:
         DOCKER_BUILDKIT: "1"
         GITHUB_TOKEN: ${{ inputs.github-token }}
       run: |
-        docker compose down -v -f ${{ inputs.docker-compose-file }} \
+        docker compose -f ${{ inputs.docker-compose-file }} down -v \
         && docker compose -f ${{ inputs.docker-compose-file }} up --build --exit-code-from test ${{ inputs.full-compose-output == 'false' && 'test' || '' }}
         echo '::set-output name=docker_up::true'
     - name: Cleanup
@@ -40,4 +40,4 @@ runs:
       shell: bash
       env:
         DOCKER_BUILDKIT: "1"
-      run: docker compose down -v -f ${{ inputs.docker-compose-file }}
+      run: docker compose -f ${{ inputs.docker-compose-file }} down -v


### PR DESCRIPTION
Previous command didn't work. Verified that `docker compose -f ./docker-compose.yaml down -v` worked locally.

<img width="992" alt="image" src="https://github.com/open-turo/actions-go/assets/16043390/102b5379-8cba-4407-a177-92e3baf14501">
