### PR TITLE
docs(prerelease): update usage of action-docs and main README.md

### DIFF
--- a/.commitlintrc.yaml
+++ b/.commitlintrc.yaml
@@ -1,2 +1,1 @@
-extends:
-  - "@open-turo/commitlint-config-conventional"
+extends: ["@open-turo/commitlint-config-conventional"]

--- a/README.md
+++ b/README.md
@@ -29,6 +29,14 @@ See usage [here](./release/README.md#usage).
 
 Documentation is found [here](./release/README.md).
 
+### action: [`prerelease`](./prerelease)
+
+Pre-release will perform the same steps as in the [`release`](./release) action but will run [GoReleaser](https://goreleaser.com/) to generate a [snapshot](https://goreleaser.com/customization/snapshots/?h=snapshot) release.
+
+See usage [here](./prerelease/README.md#usage).
+
+Documentation is found [here](./prerelease/README.md).
+
 ### action: [`test`](./test)
 
 Executes golang unit tests that exist anywhere within the consumer repository and reports test results and coverage metrics as well. [action-setup-tools](https://github.com/open-turo/action-setup-tools) will be used to install golang, honoring the version information found in the `.go-version` file found in the root level of the consumer repository.

--- a/integration-test/README.md
+++ b/integration-test/README.md
@@ -1,6 +1,43 @@
 # GitHub Action Integration-Test
 
-GitHub Action that conditionally executes integration tests via docker compose if the docker compose file is present.
+<!-- prettier-ignore-start -->
+<!-- action-docs-description source="integration-test/action.yaml" -->
+## Description
+
+Conditionally executes golang integration tests via docker, if docker compose file is found
+<!-- action-docs-description source="integration-test/action.yaml" -->
+
+<!-- action-docs-usage source="integration-test/action.yaml" -->
+## Usage
+
+```yaml
+- uses: @
+  with:
+    checkout-repo:
+    # Perform checkout as first step of action
+    #
+    # Required: false
+    # Default: true
+
+    github-token:
+    # GitHub token for docker compose. e.g. 'secrets.GITHUB_TOKEN'.
+    #
+    # Required: true
+    # Default: ""
+
+    docker-compose-file:
+    # Relative or absolute path to docker-compose.yaml file
+    #
+    # Required: false
+    # Default: ./docker-compose.yaml
+
+    full-compose-output:
+    # Set this to true to log all container output from docker-compose
+    #
+    # Required: false
+    # Default: false
+```
+<!-- action-docs-usage source="integration-test/action.yaml" -->
 
 ## Usage
 
@@ -25,3 +62,4 @@ If the docker compose file is present, the action will run:
 docker-compose up --build --exit-code-from test test
 docker-compose down
 ```
+<!-- prettier-ignore-end -->

--- a/lint/README.md
+++ b/lint/README.md
@@ -1,7 +1,11 @@
 # GitHub Action Lint
 
 <!-- prettier-ignore-start -->
-<!-- action-docs-description -->
+<!-- action-docs-description source="lint/action.yaml" -->
+## Description
+
+GitHub Action that lints a Terraform based repository via [action-pre-commit](https://github.com/open-turo/action-pre-commit)
+<!-- action-docs-description source="lint/action.yaml" -->
 ## Description
 
 GitHub Action that lints a Terraform based repository via [action-pre-commit](https://github.com/open-turo/action-pre-commit)
@@ -9,7 +13,14 @@ GitHub Action that lints a Terraform based repository via [action-pre-commit](ht
 <!-- prettier-ignore-end -->
 
 <!-- prettier-ignore-start -->
-<!-- action-docs-inputs -->
+<!-- action-docs-inputs source="lint/action.yaml" -->
+## Inputs
+
+| name | description | required | default |
+| --- | --- | --- | --- |
+| `checkout-repo` | <p>Perform checkout as first step of action</p> | `false` | `true` |
+| `github-token` | <p>GitHub token that can checkout the consumer repository. e.g. 'secrets.GITHUB_TOKEN'</p> | `true` | `""` |
+<!-- action-docs-inputs source="lint/action.yaml" -->
 ## Inputs
 
 | parameter | description | required | default |
@@ -18,16 +29,22 @@ GitHub Action that lints a Terraform based repository via [action-pre-commit](ht
 | github-token | GitHub token that can checkout the consumer repository. e.g. 'secrets.GITHUB_TOKEN' | `true` |  |
 <!-- action-docs-inputs -->
 
-<!-- action-docs-outputs -->
+<!-- action-docs-outputs source="lint/action.yaml" -->
+
+<!-- action-docs-outputs source="lint/action.yaml" -->
 
 <!-- action-docs-outputs -->
 
-<!-- action-docs-runs -->
+<!-- action-docs-runs source="lint/action.yaml" -->
+## Runs
+
+This action is a `composite` action.
+<!-- action-docs-runs source="lint/action.yaml" -->
 ## Runs
 
 This action is a `composite` action.
 <!-- action-docs-runs -->
 
-<!-- action-docs-usage  -->
+<!-- action-docs-usage source="lint/action.yaml"  -->
 <!-- action-docs-usage -->
 <!-- prettier-ignore-end -->

--- a/prerelease/README.md
+++ b/prerelease/README.md
@@ -1,25 +1,34 @@
 # GitHub Action Release
 
 <!-- prettier-ignore-start -->
-<!-- action-docs-description -->
+<!-- action-docs-description source="./prerelease/action.yaml" -->
 ## Description
 
 GitHub Action that produces a new pre-release (snapshot) of a golang based repository.
-<!-- action-docs-description -->
+<!-- action-docs-description source="./prerelease/action.yaml" -->
 <!-- prettier-ignore-end -->
 
 <!-- prettier-ignore-start -->
-<!-- action-docs-inputs -->
+<!-- action-docs-inputs source="./prerelease/action.yaml" -->
 ## Inputs
 
-| parameter | description | required | default |
+| name | description | required | default |
 | --- | --- | --- | --- |
-| checkout-repo | Perform checkout as first step of action | `false` | true |
-| github-token | GitHub token that can checkout the consumer repository as well as create tags/releases against it. e.g. 'secrets.GITHUB_TOKEN' | `true` |  |
-| go-version | Go version to use for building | `true` | 1.17.3 |
-<!-- action-docs-inputs -->
+| `checkout-repo` | <p>Perform checkout as first step of action</p> | `false` | `true` |
+| `github-token` | <p>GitHub token that can checkout the consumer repository as well as create tags/releases against it. e.g. 'secrets.GITHUB_TOKEN'</p> | `true` | `""` |
+| `go-version` | <p>Go version to use for building</p> | `true` | `1.17.3` |
+| `push-docker-snapshot` | <p>If a docker snapshot image is generated, push it to the to the registry</p> | `false` | `false` |
+| `docker-username` | <p>Docker username to push the snapshot image to the registry</p> | `false` | `""` |
+| `docker-password` | <p>Docker password to push the snapshot image to the registry</p> | `false` | `""` |
+<!-- action-docs-inputs source="./prerelease/action.yaml" -->
 
-<!-- action-docs-outputs -->
+<!-- action-docs-outputs source="./prerelease/action.yaml" -->
+## Outputs
+
+| name | description |
+| --- | --- |
+| `version` | <p>Version of the project</p> |
+<!-- action-docs-outputs source="./prerelease/action.yaml" -->
 ## Outputs
 
 | parameter | description |
@@ -27,12 +36,35 @@ GitHub Action that produces a new pre-release (snapshot) of a golang based repos
 | version | Version of the project |
 <!-- action-docs-outputs -->
 
-<!-- action-docs-runs -->
+<!-- action-docs-runs source="./prerelease/action.yaml -->
 ## Runs
 
 This action is a `composite` action.
 <!-- action-docs-runs -->
 
-<!-- action-docs-usage  -->
-<!-- action-docs-usage -->
+## Usage
+
+```yaml
+name: Prerelease
+
+on:
+  pull_request:
+    types:
+      - opened
+      - labeled
+      - synchronize
+
+jobs:
+  prerelease:
+    name: Build and push pre-release image
+    if: contains(github.event.pull_request.labels.*.name, 'prerelease')
+    steps:
+      - name: Pre-release
+        uses: open-turo/actions-go/prerelease@v2
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          push-docker-snapshot: true
+          docker-username: ${{ secrets.DOCKER_USERNAME }}
+          docker-password: ${{ secrets.DOCKER_PASSWORD }}
+```
 <!-- prettier-ignore-end -->

--- a/prerelease/README.md
+++ b/prerelease/README.md
@@ -1,15 +1,15 @@
-# GitHub Action Release
+# GitHub Action Pre-release
 
 <!-- prettier-ignore-start -->
-<!-- action-docs-description source="./prerelease/action.yaml" -->
+<!-- action-docs-description source="prerelease/action.yaml" -->
 ## Description
 
 GitHub Action that produces a new pre-release (snapshot) of a golang based repository.
-<!-- action-docs-description source="./prerelease/action.yaml" -->
+<!-- action-docs-description source="prerelease/action.yaml" -->
 <!-- prettier-ignore-end -->
 
 <!-- prettier-ignore-start -->
-<!-- action-docs-inputs source="./prerelease/action.yaml" -->
+<!-- action-docs-inputs source="prerelease/action.yaml" -->
 ## Inputs
 
 | name | description | required | default |
@@ -20,15 +20,15 @@ GitHub Action that produces a new pre-release (snapshot) of a golang based repos
 | `push-docker-snapshot` | <p>If a docker snapshot image is generated, push it to the to the registry</p> | `false` | `false` |
 | `docker-username` | <p>Docker username to push the snapshot image to the registry</p> | `false` | `""` |
 | `docker-password` | <p>Docker password to push the snapshot image to the registry</p> | `false` | `""` |
-<!-- action-docs-inputs source="./prerelease/action.yaml" -->
+<!-- action-docs-inputs source="prerelease/action.yaml" -->
 
-<!-- action-docs-outputs source="./prerelease/action.yaml" -->
+<!-- action-docs-outputs source="prerelease/action.yaml" -->
 ## Outputs
 
 | name | description |
 | --- | --- |
 | `version` | <p>Version of the project</p> |
-<!-- action-docs-outputs source="./prerelease/action.yaml" -->
+<!-- action-docs-outputs source="prerelease/action.yaml" -->
 ## Outputs
 
 | parameter | description |
@@ -36,7 +36,7 @@ GitHub Action that produces a new pre-release (snapshot) of a golang based repos
 | version | Version of the project |
 <!-- action-docs-outputs -->
 
-<!-- action-docs-runs source="./prerelease/action.yaml -->
+<!-- action-docs-runs source="prerelease/action.yaml -->
 ## Runs
 
 This action is a `composite` action.

--- a/release/README.md
+++ b/release/README.md
@@ -1,7 +1,11 @@
 # GitHub Action Release
 
 <!-- prettier-ignore-start -->
-<!-- action-docs-description -->
+<!-- action-docs-description source="release/action.yaml" -->
+## Description
+
+GitHub Action that produces a new Release of a golang based repository.
+<!-- action-docs-description source="release/action.yaml" -->
 ## Description
 
 GitHub Action that produces a new Release of a golang based repository.
@@ -9,7 +13,15 @@ GitHub Action that produces a new Release of a golang based repository.
 <!-- prettier-ignore-end -->
 
 <!-- prettier-ignore-start -->
-<!-- action-docs-inputs -->
+<!-- action-docs-inputs source="release/action.yaml" -->
+## Inputs
+
+| name | description | required | default |
+| --- | --- | --- | --- |
+| `checkout-repo` | <p>Perform checkout as first step of action</p> | `false` | `true` |
+| `github-token` | <p>GitHub token that can checkout the consumer repository as well as create tags/releases against it. e.g. 'secrets.GITHUB_TOKEN'</p> | `true` | `""` |
+| `go-version` | <p>Go version to use for building</p> | `true` | `1.17.3` |
+<!-- action-docs-inputs source="release/action.yaml" -->
 ## Inputs
 
 | parameter | description | required | default |
@@ -19,7 +31,13 @@ GitHub Action that produces a new Release of a golang based repository.
 | go-version | Go version to use for building | `true` | 1.17.3 |
 <!-- action-docs-inputs -->
 
-<!-- action-docs-outputs -->
+<!-- action-docs-outputs source="release/action.yaml" -->
+## Outputs
+
+| name | description |
+| --- | --- |
+| `version` | <p>Version of the project</p> |
+<!-- action-docs-outputs source="release/action.yaml" -->
 ## Outputs
 
 | parameter | description |
@@ -27,12 +45,40 @@ GitHub Action that produces a new Release of a golang based repository.
 | version | Version of the project |
 <!-- action-docs-outputs -->
 
-<!-- action-docs-runs -->
+<!-- action-docs-runs source="release/action.yaml" -->
+## Runs
+
+This action is a `composite` action.
+<!-- action-docs-runs source="release/action.yaml" -->
 ## Runs
 
 This action is a `composite` action.
 <!-- action-docs-runs -->
 
-<!-- action-docs-usage  -->
+<!-- action-docs-usage source="release/action.yaml" -->
+## Usage
+
+```yaml
+- uses: @
+  with:
+    checkout-repo:
+    # Perform checkout as first step of action
+    #
+    # Required: false
+    # Default: true
+
+    github-token:
+    # GitHub token that can checkout the consumer repository as well as create tags/releases against it. e.g. 'secrets.GITHUB_TOKEN'
+    #
+    # Required: true
+    # Default: ""
+
+    go-version:
+    # Go version to use for building
+    #
+    # Required: true
+    # Default: 1.17.3
+```
+<!-- action-docs-usage source="release/action.yaml" -->
 <!-- action-docs-usage -->
 <!-- prettier-ignore-end -->

--- a/script/update-action-readme
+++ b/script/update-action-readme
@@ -9,6 +9,6 @@ for i in $*; do
     continue
   fi
   readme_file=$(dirname "$i")/README.md
-  echo "npx action-docs --no-banner -a "${i}" --update-readme "${readme_file}""
-  npx action-docs --no-banner -a "${i}" --update-readme "${readme_file}"
+  echo "npx action-docs --no-banner --source "${i}" --update-readme "${readme_file}""
+  npx action-docs --no-banner --source "${i}" --update-readme "${readme_file}"
 done

--- a/test/README.md
+++ b/test/README.md
@@ -1,7 +1,11 @@
 # GitHub Action Test
 
 <!-- prettier-ignore-start -->
-<!-- action-docs-description -->
+<!-- action-docs-description source="test/action.yaml" -->
+## Description
+
+GitHub Action that executes unit tests present anywhere within a golang based GitHub repository and reports results including coverage metrics
+<!-- action-docs-description source="test/action.yaml" -->
 ## Description
 
 GitHub Action that executes unit tests present anywhere within a golang based GitHub repository and reports results including coverage metrics
@@ -9,25 +13,55 @@ GitHub Action that executes unit tests present anywhere within a golang based Gi
 <!-- prettier-ignore-end -->
 
 <!-- prettier-ignore-start -->
-<!-- action-docs-inputs -->
+<!-- action-docs-inputs source="test/action.yaml" -->
 ## Inputs
 
-| parameter | description | required | default |
+| name | description | required | default |
+| --- | --- | --- | --- |
+| `checkout-repo` | <p>Perform checkout as first step of action</p> | `false` | `true` |
+| `github-token` | <p>GitHub token that can checkout the consumer repository. e.g. 'secrets.GITHUB_TOKEN'</p> | `true` | `""` |
+<!-- action-docs-inputs source="test/action.yaml" -->
+## Inputs
+
 | --- | --- | --- | --- |
 | checkout-repo | Perform checkout as first step of action | `false` | true |
 | github-token | GitHub token that can checkout the consumer repository. e.g. 'secrets.GITHUB_TOKEN' | `true` |  |
 <!-- action-docs-inputs -->
 
-<!-- action-docs-outputs -->
+<!-- action-docs-outputs source="test/action.yaml" -->
+
+<!-- action-docs-outputs source="test/action.yaml" -->
 
 <!-- action-docs-outputs -->
 
-<!-- action-docs-runs -->
+<!-- action-docs-runs source="test/action.yaml" -->
+## Runs
+
+This action is a `composite` action.
+<!-- action-docs-runs source="test/action.yaml" -->
 ## Runs
 
 This action is a `composite` action.
 <!-- action-docs-runs -->
 
-<!-- action-docs-usage  -->
+<!-- action-docs-usage source="test/action.yaml" -->
+## Usage
+
+```yaml
+- uses: @
+  with:
+    checkout-repo:
+    # Perform checkout as first step of action
+    #
+    # Required: false
+    # Default: true
+
+    github-token:
+    # GitHub token that can checkout the consumer repository. e.g. 'secrets.GITHUB_TOKEN'
+    #
+    # Required: true
+    # Default: ""
+```
+<!-- action-docs-usage source="test/action.yaml" -->
 <!-- action-docs-usage -->
 <!-- prettier-ignore-end -->


### PR DESCRIPTION
**Description**

Docs weren't being generated automatically anymore.  This fixes all actions.



**Changes**

* docs(prerelease): update usage of action-docs and main README.md
* [docs: update usage of action-docs and main README.md for all actions](https://github.com/open-turo/actions-go/pull/40/commits/bbf87db97daa2ca2194982f565253e8213d0005a)

🚀 PR created with [fotingo](https://github.com/tagoro9/fotingo)
