### PR TITLE
Update action versions and standards

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -2,6 +2,7 @@ name: CI
 
 on:
   pull_request:
+  push:
     branches: [main]
 
 jobs:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -27,8 +27,6 @@ jobs:
       - test
     name: Release
     runs-on: ubuntu-latest
-    env:
-      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
       - uses: open-turo/actions-gha/release@v2
         env:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,4 +1,15 @@
 repos:
+  - repo: https://github.com/alessandrojcm/commitlint-pre-commit-hook
+    rev: v9.18.0
+    hooks:
+      - id: commitlint
+        stages: [commit-msg]
+        additional_dependencies: ["@open-turo/commitlint-config-conventional"]
+  - repo: https://github.com/pre-commit/mirrors-prettier
+    rev: v3.1.0
+    hooks:
+      - id: prettier
+        stages: [commit]
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v4.6.0 # Use the ref you want to point at
     hooks:
@@ -6,17 +17,10 @@ repos:
       - id: check-yaml
       - id: end-of-file-fixer
       - id: trailing-whitespace
-  - repo: https://github.com/pre-commit/mirrors-prettier
-    rev: v3.1.0
-    hooks:
-      - id: prettier
-        stages: [commit]
-  - repo: https://github.com/alessandrojcm/commitlint-pre-commit-hook
-    rev: v9.16.0
-    hooks:
-      - id: commitlint
-        stages: [commit-msg]
-        additional_dependencies: ["@open-turo/commitlint-config-conventional"]
+        exclude: |
+          (?x)^(
+            .*/README.md
+          )$
   - repo: https://github.com/rhysd/actionlint
     rev: v1.7.1
     hooks:

--- a/docs/breaking-changes/v3.md
+++ b/docs/breaking-changes/v3.md
@@ -4,4 +4,4 @@ The `go-version` input in the `release` and `prerelease` actions no longer exist
 
 The action will use the installed version in the runner.
 
-The `push-docker-snapshot` input in the `prerelease` action no longer exists. Instead, set the `create-release` input to true.
+The `push-docker-snapshot` input in the `prerelease` action no longer exists. Instead, set the `create-prerelease` input to true.

--- a/docs/breaking-changes/v3.md
+++ b/docs/breaking-changes/v3.md
@@ -1,0 +1,7 @@
+# Breaking changes in v3
+
+The `go-version` input in the `release` and `prerelease` actions no longer exists.
+
+The action will use the installed version in the runner.
+
+The `push-docker-snapshot` input in the `prerelease` action no longer exists. Instead, set the `create-release` input to true.

--- a/integration-test/README.md
+++ b/integration-test/README.md
@@ -1,13 +1,13 @@
 # GitHub Action Integration-Test
 
 <!-- prettier-ignore-start -->
-<!-- action-docs-description source="integration-test/action.yaml" -->
+<!-- action-docs-description source="action.yaml" -->
 ## Description
 
 Conditionally executes golang integration tests via docker, if docker compose file is found
-<!-- action-docs-description source="integration-test/action.yaml" -->
+<!-- action-docs-description source="action.yaml" -->
 
-<!-- action-docs-usage source="integration-test/action.yaml" -->
+<!-- action-docs-usage source="action.yaml" -->
 ## Usage
 
 ```yaml
@@ -37,7 +37,7 @@ Conditionally executes golang integration tests via docker, if docker compose fi
     # Required: false
     # Default: false
 ```
-<!-- action-docs-usage source="integration-test/action.yaml" -->
+<!-- action-docs-usage source="action.yaml" -->
 
 ## Usage
 

--- a/lint/README.md
+++ b/lint/README.md
@@ -1,11 +1,11 @@
 # GitHub Action Lint
 
 <!-- prettier-ignore-start -->
-<!-- action-docs-description source="lint/action.yaml" -->
+<!-- action-docs-description source="action.yaml" -->
 ## Description
 
 GitHub Action that lints a Terraform based repository via [action-pre-commit](https://github.com/open-turo/action-pre-commit)
-<!-- action-docs-description source="lint/action.yaml" -->
+<!-- action-docs-description source="action.yaml" -->
 ## Description
 
 GitHub Action that lints a Terraform based repository via [action-pre-commit](https://github.com/open-turo/action-pre-commit)
@@ -13,14 +13,14 @@ GitHub Action that lints a Terraform based repository via [action-pre-commit](ht
 <!-- prettier-ignore-end -->
 
 <!-- prettier-ignore-start -->
-<!-- action-docs-inputs source="lint/action.yaml" -->
+<!-- action-docs-inputs source="action.yaml" -->
 ## Inputs
 
 | name | description | required | default |
 | --- | --- | --- | --- |
 | `checkout-repo` | <p>Perform checkout as first step of action</p> | `false` | `true` |
 | `github-token` | <p>GitHub token that can checkout the consumer repository. e.g. 'secrets.GITHUB_TOKEN'</p> | `true` | `""` |
-<!-- action-docs-inputs source="lint/action.yaml" -->
+<!-- action-docs-inputs source="action.yaml" -->
 ## Inputs
 
 | parameter | description | required | default |
@@ -29,22 +29,22 @@ GitHub Action that lints a Terraform based repository via [action-pre-commit](ht
 | github-token | GitHub token that can checkout the consumer repository. e.g. 'secrets.GITHUB_TOKEN' | `true` |  |
 <!-- action-docs-inputs -->
 
-<!-- action-docs-outputs source="lint/action.yaml" -->
+<!-- action-docs-outputs source="action.yaml" -->
 
-<!-- action-docs-outputs source="lint/action.yaml" -->
+<!-- action-docs-outputs source="action.yaml" -->
 
 <!-- action-docs-outputs -->
 
-<!-- action-docs-runs source="lint/action.yaml" -->
+<!-- action-docs-runs source="action.yaml" -->
 ## Runs
 
 This action is a `composite` action.
-<!-- action-docs-runs source="lint/action.yaml" -->
+<!-- action-docs-runs source="action.yaml" -->
 ## Runs
 
 This action is a `composite` action.
 <!-- action-docs-runs -->
 
-<!-- action-docs-usage source="lint/action.yaml"  -->
+<!-- action-docs-usage source="action.yaml"  -->
 <!-- action-docs-usage -->
 <!-- prettier-ignore-end -->

--- a/lint/action.yaml
+++ b/lint/action.yaml
@@ -22,11 +22,11 @@ runs:
       # Provide opportunity to install terraform, golang, and others
       uses: open-turo/action-setup-tools@v2
     - name: Authorize
-      uses: open-turo/action-git-auth@v2
+      uses: open-turo/action-git-auth@v3
       with:
         github-personal-access-token: ${{ inputs.github-token }}
     - name: Pre-commit
-      uses: open-turo/action-pre-commit@v2
+      uses: open-turo/action-pre-commit@v3
     - name: Check release notes on pull_request
       if: github.event_name == 'pull_request'
-      uses: open-turo/actions-release/lint-release-notes@v4
+      uses: open-turo/actions-release/lint-release-notes@v5

--- a/prerelease/README.md
+++ b/prerelease/README.md
@@ -18,8 +18,8 @@ GitHub Action that produces a new pre-release (snapshot) of a golang based repos
 | `checkout-fetch-depth` | <p>The number of commits to fetch. 0 indicates all history for all branches and tags</p> | `false` | `0` |
 | `create-prerelease` | <p>Whether semantic-release should create a prerelease or do a dry run. This can be useful to set to true when a prerelease requires pushing artifacts semantic-release is in charge of generating</p> | `false` | `false` |
 | `github-token` | <p>GitHub token that can checkout the consumer repository as well as create tags/releases against it. e.g. 'secrets.GITHUB_TOKEN'</p> | `true` | `""` |
-| `docker-username` | <p>Docker username to push the snapshot image to the registry</p> | `false` | `""` |
-| `docker-password` | <p>Docker password to push the snapshot image to the registry</p> | `false` | `""` |
+| `docker-username` | <p>Docker username to push the prerelease image to the registry</p> | `false` | `""` |
+| `docker-password` | <p>Docker password to push the prerelease image to the registry</p> | `false` | `""` |
 | `extra-plugins` | <p>Extra plugins for pre-install. You can also specify specifying version range for the extra plugins if you prefer.  Defaults to install @open-turo/semantic-release-config.</p> | `false` | `@open-turo/semantic-release-config ` |
 <!-- action-docs-inputs source="action.yaml" -->
 

--- a/prerelease/README.md
+++ b/prerelease/README.md
@@ -1,34 +1,37 @@
 # GitHub Action Pre-release
 
 <!-- prettier-ignore-start -->
-<!-- action-docs-description source="prerelease/action.yaml" -->
+<!-- action-docs-description source="action.yaml" -->
 ## Description
 
 GitHub Action that produces a new pre-release (snapshot) of a golang based repository.
-<!-- action-docs-description source="prerelease/action.yaml" -->
+<!-- action-docs-description source="action.yaml" -->
 <!-- prettier-ignore-end -->
 
 <!-- prettier-ignore-start -->
-<!-- action-docs-inputs source="prerelease/action.yaml" -->
+<!-- action-docs-inputs source="action.yaml" -->
 ## Inputs
 
 | name | description | required | default |
 | --- | --- | --- | --- |
 | `checkout-repo` | <p>Perform checkout as first step of action</p> | `false` | `true` |
+| `checkout-fetch-depth` | <p>The number of commits to fetch. 0 indicates all history for all branches and tags</p> | `false` | `0` |
+| `create-prerelease` | <p>Whether semantic-release should create a prerelease or do a dry run. This can be useful to set to true when a prerelease requires pushing artifacts semantic-release is in charge of generating</p> | `false` | `false` |
 | `github-token` | <p>GitHub token that can checkout the consumer repository as well as create tags/releases against it. e.g. 'secrets.GITHUB_TOKEN'</p> | `true` | `""` |
 | `go-version` | <p>Go version to use for building</p> | `true` | `1.17.3` |
 | `push-docker-snapshot` | <p>If a docker snapshot image is generated, push it to the to the registry</p> | `false` | `false` |
 | `docker-username` | <p>Docker username to push the snapshot image to the registry</p> | `false` | `""` |
 | `docker-password` | <p>Docker password to push the snapshot image to the registry</p> | `false` | `""` |
-<!-- action-docs-inputs source="prerelease/action.yaml" -->
+| `extra-plugins` | <p>Extra plugins for pre-install. You can also specify specifying version range for the extra plugins if you prefer.  Defaults to install @open-turo/semantic-release-config.</p> | `false` | `@open-turo/semantic-release-config ` |
+<!-- action-docs-inputs source="action.yaml" -->
 
-<!-- action-docs-outputs source="prerelease/action.yaml" -->
+<!-- action-docs-outputs source="action.yaml" -->
 ## Outputs
 
 | name | description |
 | --- | --- |
 | `version` | <p>Version of the project</p> |
-<!-- action-docs-outputs source="prerelease/action.yaml" -->
+<!-- action-docs-outputs source="action.yaml" -->
 ## Outputs
 
 | parameter | description |
@@ -36,7 +39,7 @@ GitHub Action that produces a new pre-release (snapshot) of a golang based repos
 | version | Version of the project |
 <!-- action-docs-outputs -->
 
-<!-- action-docs-runs source="prerelease/action.yaml -->
+<!-- action-docs-runs source="action.yaml -->
 ## Runs
 
 This action is a `composite` action.

--- a/prerelease/README.md
+++ b/prerelease/README.md
@@ -18,8 +18,6 @@ GitHub Action that produces a new pre-release (snapshot) of a golang based repos
 | `checkout-fetch-depth` | <p>The number of commits to fetch. 0 indicates all history for all branches and tags</p> | `false` | `0` |
 | `create-prerelease` | <p>Whether semantic-release should create a prerelease or do a dry run. This can be useful to set to true when a prerelease requires pushing artifacts semantic-release is in charge of generating</p> | `false` | `false` |
 | `github-token` | <p>GitHub token that can checkout the consumer repository as well as create tags/releases against it. e.g. 'secrets.GITHUB_TOKEN'</p> | `true` | `""` |
-| `go-version` | <p>Go version to use for building</p> | `true` | `1.17.3` |
-| `push-docker-snapshot` | <p>If a docker snapshot image is generated, push it to the to the registry</p> | `false` | `false` |
 | `docker-username` | <p>Docker username to push the snapshot image to the registry</p> | `false` | `""` |
 | `docker-password` | <p>Docker password to push the snapshot image to the registry</p> | `false` | `""` |
 | `extra-plugins` | <p>Extra plugins for pre-install. You can also specify specifying version range for the extra plugins if you prefer.  Defaults to install @open-turo/semantic-release-config.</p> | `false` | `@open-turo/semantic-release-config ` |

--- a/prerelease/action.yaml
+++ b/prerelease/action.yaml
@@ -5,23 +5,28 @@ inputs:
     required: false
     description: Perform checkout as first step of action
     default: "true"
+  checkout-fetch-depth:
+    required: false
+    description: The number of commits to fetch. 0 indicates all history for all branches and tags
+    default: "0"
+  create-prerelease:
+    required: false
+    description: Whether semantic-release should create a prerelease or do a dry run. This can be useful to set to true when a prerelease requires pushing artifacts semantic-release is in charge of generating
+    default: "false"
   github-token:
     description: GitHub token that can checkout the consumer repository as well as create tags/releases against it. e.g. 'secrets.GITHUB_TOKEN'
     required: true
-  go-version:
-    description: Go version to use for building
-    required: true
-    default: 1.17.3
-  push-docker-snapshot:
-    description: If a docker snapshot image is generated, push it to the to the registry
-    required: false
-    default: "false"
   docker-username:
     description: Docker username to push the snapshot image to the registry
     required: false
   docker-password:
     description: Docker password to push the snapshot image to the registry
     required: false
+  extra-plugins:
+    required: false
+    description: Extra plugins for pre-install. You can also specify specifying version range for the extra plugins if you prefer.  Defaults to install @open-turo/semantic-release-config.
+    default: |
+      @open-turo/semantic-release-config
 outputs:
   version:
     description: Version of the project
@@ -29,43 +34,165 @@ outputs:
 runs:
   using: composite
   steps:
+    - name: Set vars
+      id: source-vars
+      shell: bash
+      env:
+        event_name: ${{ github.event_name }}
+        dispatch_client_payload_ref: ${{ github.event.client_payload.ref }}
+        dispatch_client_payload_sha: ${{ github.event.client_payload.sha }}
+        push_ref_name: ${{ github.ref_name }}
+        push_sha: ${{ github.sha }}
+        pull_request_ref_name: ${{ github.event.pull_request.head.ref }}
+        pull_request_sha: ${{ github.event.pull_request.head.sha }}
+      run: |
+        echo "event_name=$event_name"
+
+        if [ "$event_name" == "push" ]; then
+          branch=$push_ref_name
+          sha=$push_sha
+        elif [ "$event_name" == "repository_dispatch" ]; then
+          branch=$dispatch_client_payload_ref
+          sha=$dispatch_client_payload_sha
+        elif [ "$event_name" == "pull_request" ]; then
+          branch=$pull_request_ref_name
+          sha=$pull_request_sha
+        else
+          echo "::error::Unsupported event type '$event_name'"
+          exit 1
+        fi
+
+        echo "branch=$branch"
+        echo "branch=$branch" >> $GITHUB_OUTPUT
+
+        echo "sha=$sha"
+        echo "sha=$sha" >> $GITHUB_OUTPUT
+
     - name: Checkout
       uses: actions/checkout@v4
       if: inputs.checkout-repo == 'true'
       with:
-        fetch-depth: 0
+        fetch-depth: ${{ inputs.checkout-fetch-depth }}
+        ref: ${{ steps.source-vars.outputs.branch }}
+
+    # Find PR
+    - uses: 8BitJonny/gh-get-current-pr@3.0.0
+      id: PR
+      with:
+        sha: ${{ steps.source-vars.outputs.sha }}
+
+    - id: check-pr
+      shell: bash
+      run: |
+        if [ -z "${{ steps.PR.outputs.number }}" ]; then
+          echo "pr_found=false" >> $GITHUB_OUTPUT
+          echo "has_prerelease_label=false" >> $GITHUB_OUTPUT
+        else
+          echo "pr_found=true" >> $GITHUB_OUTPUT
+          echo "has_prerelease_label=${{ contains(toJSON(fromJSON(steps.PR.outputs.pr).labels.*.name), 'prerelease') }}" >> $GITHUB_OUTPUT
+        fi
+        git branch
+        echo "branch: ${{ steps.source-vars.outputs.branch }}"
+
+    # Allow the action to download any private dependency in the go library
     - name: Authorize
-      uses: open-turo/action-git-auth@v2
+      uses: open-turo/action-git-auth@v3
       with:
         github-personal-access-token: ${{ inputs.github-token }}
+
     - name: Setup tools
       ## Installs version of golang found in .go-version
       uses: open-turo/action-setup-tools@v2
-    - name: Semantic release
-      uses: go-semantic-release/action@v1
-      id: release
+
+    - name: Prerelease
+      id: prerelease
+      uses: open-turo/actions-release/semantic-release@v5
+      if: steps.check-pr.outputs.has_prerelease_label == 'true'
       with:
+        branches: '["${{ github.event.repository.default_branch }}", {"name": "${{ steps.source-vars.outputs.branch }}","channel": "next","prerelease": "pr-${{ steps.PR.outputs.number }}.${{ github.run_number }}.${{ github.run_attempt }}"}]'
+        dry-run: ${{ inputs.create-prerelease == 'false' }}
+        extra-plugins: ${{ inputs.extra-plugins }}
         github-token: ${{ inputs.github-token }}
-    - name: Goreleaser
-      uses: goreleaser/goreleaser-action@v6
+        override-github-ref-name: ${{ steps.source-vars.outputs.branch }}
       env:
         GITHUB_TOKEN: ${{ inputs.github-token }}
-        GOVERSION: ${{ inputs.go-version }}
-      with:
-        args: release --snapshot
+    - id: vars
+      if: steps.check-pr.outputs.has_prerelease_label == 'true'
+      shell: bash
+      run: |
+        echo "version=${{ steps.prerelease.outputs.new-release-version }}" >> $GITHUB_OUTPUT
+        echo "run-url=https://github.com/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID" >> "$GITHUB_OUTPUT"
+
     - name: Docker login
-      if: inputs.push-docker-snapshot == 'true'
+      if: inputs.docker-username != '' && inputs.docker-password != '' && steps.prerelease.outputs.new-release-version != ''
       uses: docker/login-action@v3
       with:
         username: ${{ inputs.docker-username }}
         password: ${{ inputs.docker-password }}
-    - name: Push Snapshot Image
-      if: inputs.push-docker-snapshot == 'true'
+
+    - name: Goreleaser
+      uses: goreleaser/goreleaser-action@v6
+      if: steps.prerelease.outputs.new-release-published == 'true'
+      id: goreleaser
+      env:
+        GITHUB_TOKEN: ${{ inputs.github-token }}
+      with:
+        args: release
+
+    - name: Get docker artifacts
+      id: get-docker-artifacts
+      if: steps.prerelease.outputs.new-release-published == 'true'
       shell: bash
+      env:
+        GORELEASER_ARTIFACTS: ${{ steps.goreleaser.outputs.artifacts }}
       run: |
-        # Selects all the docker images that are not the latest tag.
-        # Maybe this doesn't cover all the cases and we could add an input to specify the tag format to push.
-        DOCKER_IMAGES=$(jq -r '.[] | select(.type == "Docker Image") | .path' dist/artifacts.json | grep -v ':latest')
-        for image in $DOCKER_IMAGES; do
-          docker push $image
-        done
+        ARTIFACTS="$(echo $GORELEASER_ARTIFACTS | jq -r '[.[] | select(.type == "Docker Image") | .name ][0]')"
+        echo "artifacts=$ARTIFACTS" >> $GITHUB_OUTPUT
+
+    - name: Add new version to summary
+      shell: bash
+      if: steps.prerelease.outputs.new-release-published == 'true'
+      env:
+        NEW_VERSION: ${{ steps.vars.outputs.version }}
+        GORELEASER_ARTIFACTS: ${{ steps.get-docker-artifacts.outputs.artifacts }}
+      run: |
+        echo "::notice::new version: \`${NEW_VERSION}\`"
+        echo "#### New version: \`${NEW_VERSION}\`" >> $GITHUB_STEP_SUMMARY
+        echo "#### Artifacts: ${GORELEASER_ARTIFACTS}" >> $GITHUB_STEP_SUMMARY
+
+    - name: Add no new version to summary
+      shell: bash
+      if: steps.prerelease.outputs.new-release-published != 'true'
+      run: |
+        echo "::notice::no new version"
+        echo "### New version: 'NONE" >> $GITHUB_STEP_SUMMARY
+
+    - name: Check for release notes comment
+      uses: peter-evans/find-comment@v3
+      id: fc-prerelease
+      if: steps.prerelease.outputs.new-release-published == 'true'
+      with:
+        issue-number: ${{ steps.PR.outputs.number }}
+        comment-author: "github-actions[bot]"
+        body-includes: "<!-- prerelease comment -->"
+    - name: Delete previous release note
+      if: steps.fc-prerelease.outputs.comment-id != ''
+      uses: winterjung/comment@v1
+      with:
+        type: delete
+        comment_id: ${{ steps.fc-prerelease.outputs.comment-id }}
+        token: ${{ inputs.github-token }}
+
+    - name: Upsert build version
+      if: steps.prerelease.outputs.new-release-published == 'true'
+      uses: peter-evans/create-or-update-comment@v4
+      with:
+        issue-number: ${{ steps.PR.outputs.number }}
+        body: |
+          <!-- prerelease comment -->
+          ## Prerelease build
+
+          **Build version:** `${{ steps.vars.outputs.version }}`
+          **Artifacts:** `${{ steps.get-docker-artifacts.outputs.artifacts }}`
+
+          [Build output](${{ steps.vars.outputs.run-url }})

--- a/prerelease/action.yaml
+++ b/prerelease/action.yaml
@@ -17,10 +17,10 @@ inputs:
     description: GitHub token that can checkout the consumer repository as well as create tags/releases against it. e.g. 'secrets.GITHUB_TOKEN'
     required: true
   docker-username:
-    description: Docker username to push the snapshot image to the registry
+    description: Docker username to push the prerelease image to the registry
     required: false
   docker-password:
-    description: Docker password to push the snapshot image to the registry
+    description: Docker password to push the prerelease image to the registry
     required: false
   extra-plugins:
     required: false

--- a/release/README.md
+++ b/release/README.md
@@ -21,9 +21,10 @@ GitHub Action that produces a new Release of a golang based repository.
 | `checkout-repo` | <p>Perform checkout as first step of action</p> | `false` | `true` |
 | `checkout-fetch-depth` | <p>The number of commits to fetch. 0 indicates all history for all branches and tags</p> | `false` | `0` |
 | `github-token` | <p>GitHub token that can checkout the consumer repository as well as create tags/releases against it. e.g. 'secrets.GITHUB_TOKEN'</p> | `true` | `""` |
-| `go-version` | <p>Go version to use for building</p> | `true` | `1.17.3` |
 | `dry-run` | <p>Whether to run semantic release in <code>dry-run</code> mode. It will override the <code>dryRun</code> attribute in your configuration file</p> | `false` | `false` |
 | `extra-plugins` | <p>Extra plugins for pre-install. You can also specify specifying version range for the extra plugins if you prefer.  Defaults to install @open-turo/semantic-release-config.</p> | `false` | `@open-turo/semantic-release-config ` |
+| `docker-username` | <p>Docker username to push the snapshot image to the registry</p> | `false` | `""` |
+| `docker-password` | <p>Docker password to push the snapshot image to the registry</p> | `false` | `""` |
 <!-- action-docs-inputs source="action.yaml" -->
 ## Inputs
 
@@ -82,12 +83,6 @@ This action is a `composite` action.
     # Required: true
     # Default: ""
 
-    go-version:
-    # Go version to use for building
-    #
-    # Required: true
-    # Default: 1.17.3
-
     dry-run:
     # Whether to run semantic release in `dry-run` mode. It will override the `dryRun` attribute in your configuration file
     #
@@ -99,6 +94,18 @@ This action is a `composite` action.
     #
     # Required: false
     # Default: @open-turo/semantic-release-config 
+
+    docker-username:
+    # Docker username to push the snapshot image to the registry
+    #
+    # Required: false
+    # Default: ""
+
+    docker-password:
+    # Docker password to push the snapshot image to the registry
+    #
+    # Required: false
+    # Default: ""
 ```
 <!-- action-docs-usage source="action.yaml" -->
 <!-- action-docs-usage -->

--- a/release/README.md
+++ b/release/README.md
@@ -23,8 +23,8 @@ GitHub Action that produces a new Release of a golang based repository.
 | `github-token` | <p>GitHub token that can checkout the consumer repository as well as create tags/releases against it. e.g. 'secrets.GITHUB_TOKEN'</p> | `true` | `""` |
 | `dry-run` | <p>Whether to run semantic release in <code>dry-run</code> mode. It will override the <code>dryRun</code> attribute in your configuration file</p> | `false` | `false` |
 | `extra-plugins` | <p>Extra plugins for pre-install. You can also specify specifying version range for the extra plugins if you prefer.  Defaults to install @open-turo/semantic-release-config.</p> | `false` | `@open-turo/semantic-release-config ` |
-| `docker-username` | <p>Docker username to push the snapshot image to the registry</p> | `false` | `""` |
-| `docker-password` | <p>Docker password to push the snapshot image to the registry</p> | `false` | `""` |
+| `docker-username` | <p>Docker username to push the release image to the registry</p> | `false` | `""` |
+| `docker-password` | <p>Docker password to push the release image to the registry</p> | `false` | `""` |
 <!-- action-docs-inputs source="action.yaml" -->
 ## Inputs
 
@@ -96,13 +96,13 @@ This action is a `composite` action.
     # Default: @open-turo/semantic-release-config 
 
     docker-username:
-    # Docker username to push the snapshot image to the registry
+    # Docker username to push the release image to the registry
     #
     # Required: false
     # Default: ""
 
     docker-password:
-    # Docker password to push the snapshot image to the registry
+    # Docker password to push the release image to the registry
     #
     # Required: false
     # Default: ""

--- a/release/README.md
+++ b/release/README.md
@@ -1,11 +1,11 @@
 # GitHub Action Release
 
 <!-- prettier-ignore-start -->
-<!-- action-docs-description source="release/action.yaml" -->
+<!-- action-docs-description source="action.yaml" -->
 ## Description
 
 GitHub Action that produces a new Release of a golang based repository.
-<!-- action-docs-description source="release/action.yaml" -->
+<!-- action-docs-description source="action.yaml" -->
 ## Description
 
 GitHub Action that produces a new Release of a golang based repository.
@@ -13,15 +13,18 @@ GitHub Action that produces a new Release of a golang based repository.
 <!-- prettier-ignore-end -->
 
 <!-- prettier-ignore-start -->
-<!-- action-docs-inputs source="release/action.yaml" -->
+<!-- action-docs-inputs source="action.yaml" -->
 ## Inputs
 
 | name | description | required | default |
 | --- | --- | --- | --- |
 | `checkout-repo` | <p>Perform checkout as first step of action</p> | `false` | `true` |
+| `checkout-fetch-depth` | <p>The number of commits to fetch. 0 indicates all history for all branches and tags</p> | `false` | `0` |
 | `github-token` | <p>GitHub token that can checkout the consumer repository as well as create tags/releases against it. e.g. 'secrets.GITHUB_TOKEN'</p> | `true` | `""` |
 | `go-version` | <p>Go version to use for building</p> | `true` | `1.17.3` |
-<!-- action-docs-inputs source="release/action.yaml" -->
+| `dry-run` | <p>Whether to run semantic release in <code>dry-run</code> mode. It will override the <code>dryRun</code> attribute in your configuration file</p> | `false` | `false` |
+| `extra-plugins` | <p>Extra plugins for pre-install. You can also specify specifying version range for the extra plugins if you prefer.  Defaults to install @open-turo/semantic-release-config.</p> | `false` | `@open-turo/semantic-release-config ` |
+<!-- action-docs-inputs source="action.yaml" -->
 ## Inputs
 
 | parameter | description | required | default |
@@ -31,13 +34,13 @@ GitHub Action that produces a new Release of a golang based repository.
 | go-version | Go version to use for building | `true` | 1.17.3 |
 <!-- action-docs-inputs -->
 
-<!-- action-docs-outputs source="release/action.yaml" -->
+<!-- action-docs-outputs source="action.yaml" -->
 ## Outputs
 
 | name | description |
 | --- | --- |
 | `version` | <p>Version of the project</p> |
-<!-- action-docs-outputs source="release/action.yaml" -->
+<!-- action-docs-outputs source="action.yaml" -->
 ## Outputs
 
 | parameter | description |
@@ -45,17 +48,17 @@ GitHub Action that produces a new Release of a golang based repository.
 | version | Version of the project |
 <!-- action-docs-outputs -->
 
-<!-- action-docs-runs source="release/action.yaml" -->
+<!-- action-docs-runs source="action.yaml" -->
 ## Runs
 
 This action is a `composite` action.
-<!-- action-docs-runs source="release/action.yaml" -->
+<!-- action-docs-runs source="action.yaml" -->
 ## Runs
 
 This action is a `composite` action.
 <!-- action-docs-runs -->
 
-<!-- action-docs-usage source="release/action.yaml" -->
+<!-- action-docs-usage source="action.yaml" -->
 ## Usage
 
 ```yaml
@@ -66,6 +69,12 @@ This action is a `composite` action.
     #
     # Required: false
     # Default: true
+
+    checkout-fetch-depth:
+    # The number of commits to fetch. 0 indicates all history for all branches and tags
+    #
+    # Required: false
+    # Default: 0
 
     github-token:
     # GitHub token that can checkout the consumer repository as well as create tags/releases against it. e.g. 'secrets.GITHUB_TOKEN'
@@ -78,7 +87,19 @@ This action is a `composite` action.
     #
     # Required: true
     # Default: 1.17.3
+
+    dry-run:
+    # Whether to run semantic release in `dry-run` mode. It will override the `dryRun` attribute in your configuration file
+    #
+    # Required: false
+    # Default: false
+
+    extra-plugins:
+    # Extra plugins for pre-install. You can also specify specifying version range for the extra plugins if you prefer.  Defaults to install @open-turo/semantic-release-config.
+    #
+    # Required: false
+    # Default: @open-turo/semantic-release-config 
 ```
-<!-- action-docs-usage source="release/action.yaml" -->
+<!-- action-docs-usage source="action.yaml" -->
 <!-- action-docs-usage -->
 <!-- prettier-ignore-end -->

--- a/release/action.yaml
+++ b/release/action.yaml
@@ -5,13 +5,28 @@ inputs:
     required: false
     description: Perform checkout as first step of action
     default: "true"
+  checkout-fetch-depth:
+    required: false
+    description: The number of commits to fetch. 0 indicates all history for all branches and tags
+    default: "0"
   github-token:
     description: GitHub token that can checkout the consumer repository as well as create tags/releases against it. e.g. 'secrets.GITHUB_TOKEN'
     required: true
-  go-version:
-    description: Go version to use for building
-    required: true
-    default: 1.17.3
+  dry-run:
+    required: false
+    description: Whether to run semantic release in `dry-run` mode. It will override the `dryRun` attribute in your configuration file
+    default: "false"
+  extra-plugins:
+    required: false
+    description: Extra plugins for pre-install. You can also specify specifying version range for the extra plugins if you prefer.  Defaults to install @open-turo/semantic-release-config.
+    default: |
+      @open-turo/semantic-release-config
+  docker-username:
+    description: Docker username to push the snapshot image to the registry
+    required: false
+  docker-password:
+    description: Docker password to push the snapshot image to the registry
+    required: false
 outputs:
   version:
     description: Version of the project
@@ -23,29 +38,55 @@ runs:
       uses: actions/checkout@v4
       if: inputs.checkout-repo == 'true'
       with:
-        fetch-depth: 0
-    - name: Authorize
-      uses: open-turo/action-git-auth@v2
+        fetch-depth: ${{ inputs.checkout-fetch-depth }}
+        persist-credentials: false
+    - uses: 8BitJonny/gh-get-current-pr@3.0.0
+      id: PR
       with:
-        github-personal-access-token: ${{ inputs.github-token }}
-    - name: Setup tools
-      ## Installs version of golang found in .go-version
-      uses: open-turo/action-setup-tools@v2
-    - name: Semantic release
-      uses: go-semantic-release/action@v1
-      id: release
-      with:
-        github-token: ${{ inputs.github-token }}
-    - name: Fetch tags
+        sha: ${{ github.event.pull_request.head.sha }}
+    - name: Branches configuration
+      id: branches-configuration
       shell: bash
       run: |
-        git fetch --tags
-        git clean -fd
+        if [ -z "${{ steps.PR.outputs.number }}" ]; then
+          echo "branches=${{ github.event.repository.default_branch }}" >> $GITHUB_OUTPUT
+        else
+          echo "branches=[\"${{ github.event.repository.default_branch }}\", {\"name\": \"${{ github.ref_name }}\",\"channel\": \"next\",\"prerelease\": \"pr-${{ steps.PR.outputs.number }}.${{ github.run_number }}.${{ github.run_attempt }}\"}]" >> $GITHUB_OUTPUT
+        fi
+    # Allow the action to download any private dependency in the go library
+    - name: Authorize
+      uses: open-turo/action-git-auth@v3
+      with:
+        github-personal-access-token: ${{ inputs.github-token }}
+    - name: Release
+      id: release
+      uses: open-turo/actions-release/semantic-release@v5
+      with:
+        branches: ${{ steps.branches-configuration.outputs.branches }}
+        dry-run: ${{ inputs.dry-run }}
+        extra-plugins: ${{ inputs.extra-plugins }}
+        github-token: ${{ inputs.github-token }}
+      env:
+        GITHUB_TOKEN: ${{ inputs.github-token }}
+
+    - name: Docker login
+      uses: docker/login-action@v3
+      if: inputs.docker-user != '' && inputs.docker-password != '' && steps.release.outputs.new-release-version != ''
+      with:
+        username: ${{ inputs.docker-username }}
+        password: ${{ inputs.docker-password }}
+
+    - name: Set args
+      id: goreleaser-args
+      shell: bash
+      run: |
+        if [[ "${{ inputs.dry-run }}" == "true" ]]; then
+            echo "args=--skip-publish" >> $GITHUB_OUTPUT
+        fi
     - name: Goreleaser
       uses: goreleaser/goreleaser-action@v6
       env:
         GITHUB_TOKEN: ${{ inputs.github-token }}
         GOPRIVATE: github.com/turo/
-        GOVERSION: ${{ inputs.go-version }}
       with:
-        args: release
+        args: release ${{ steps.goreleaser-args.outputs.args }}

--- a/release/action.yaml
+++ b/release/action.yaml
@@ -30,7 +30,7 @@ runs:
         github-personal-access-token: ${{ inputs.github-token }}
     - name: Setup tools
       ## Installs version of golang found in .go-version
-      uses: open-turo/action-setup-tools@v1
+      uses: open-turo/action-setup-tools@v2
     - name: Semantic release
       uses: go-semantic-release/action@v1
       id: release

--- a/release/action.yaml
+++ b/release/action.yaml
@@ -22,10 +22,10 @@ inputs:
     default: |
       @open-turo/semantic-release-config
   docker-username:
-    description: Docker username to push the snapshot image to the registry
+    description: Docker username to push the release image to the registry
     required: false
   docker-password:
-    description: Docker password to push the snapshot image to the registry
+    description: Docker password to push the release image to the registry
     required: false
 outputs:
   version:

--- a/script/update-action-readme
+++ b/script/update-action-readme
@@ -8,7 +8,9 @@ for i in $*; do
     echo "skipping: ${i}"
     continue
   fi
-  readme_file=$(dirname "$i")/README.md
-  echo "npx action-docs --no-banner --source "${i}" --update-readme "${readme_file}""
-  npx action-docs --no-banner --source "${i}" --update-readme "${readme_file}"
+
+  echo "npx action-docs --no-banner -s "${i}""
+  cd $(dirname "$i")
+  npx action-docs@2 --no-banner -s action.yaml -u README.md || echo "action-docs failed for $i"
+  cd -
 done

--- a/test/README.md
+++ b/test/README.md
@@ -1,11 +1,11 @@
 # GitHub Action Test
 
 <!-- prettier-ignore-start -->
-<!-- action-docs-description source="test/action.yaml" -->
+<!-- action-docs-description source="action.yaml" -->
 ## Description
 
 GitHub Action that executes unit tests present anywhere within a golang based GitHub repository and reports results including coverage metrics
-<!-- action-docs-description source="test/action.yaml" -->
+<!-- action-docs-description source="action.yaml" -->
 ## Description
 
 GitHub Action that executes unit tests present anywhere within a golang based GitHub repository and reports results including coverage metrics
@@ -13,14 +13,14 @@ GitHub Action that executes unit tests present anywhere within a golang based Gi
 <!-- prettier-ignore-end -->
 
 <!-- prettier-ignore-start -->
-<!-- action-docs-inputs source="test/action.yaml" -->
+<!-- action-docs-inputs source="action.yaml" -->
 ## Inputs
 
 | name | description | required | default |
 | --- | --- | --- | --- |
 | `checkout-repo` | <p>Perform checkout as first step of action</p> | `false` | `true` |
 | `github-token` | <p>GitHub token that can checkout the consumer repository. e.g. 'secrets.GITHUB_TOKEN'</p> | `true` | `""` |
-<!-- action-docs-inputs source="test/action.yaml" -->
+<!-- action-docs-inputs source="action.yaml" -->
 ## Inputs
 
 | --- | --- | --- | --- |
@@ -28,23 +28,23 @@ GitHub Action that executes unit tests present anywhere within a golang based Gi
 | github-token | GitHub token that can checkout the consumer repository. e.g. 'secrets.GITHUB_TOKEN' | `true` |  |
 <!-- action-docs-inputs -->
 
-<!-- action-docs-outputs source="test/action.yaml" -->
+<!-- action-docs-outputs source="action.yaml" -->
 
-<!-- action-docs-outputs source="test/action.yaml" -->
+<!-- action-docs-outputs source="action.yaml" -->
 
 <!-- action-docs-outputs -->
 
-<!-- action-docs-runs source="test/action.yaml" -->
+<!-- action-docs-runs source="action.yaml" -->
 ## Runs
 
 This action is a `composite` action.
-<!-- action-docs-runs source="test/action.yaml" -->
+<!-- action-docs-runs source="action.yaml" -->
 ## Runs
 
 This action is a `composite` action.
 <!-- action-docs-runs -->
 
-<!-- action-docs-usage source="test/action.yaml" -->
+<!-- action-docs-usage source="action.yaml" -->
 ## Usage
 
 ```yaml
@@ -62,6 +62,6 @@ This action is a `composite` action.
     # Required: true
     # Default: ""
 ```
-<!-- action-docs-usage source="test/action.yaml" -->
+<!-- action-docs-usage source="action.yaml" -->
 <!-- action-docs-usage -->
 <!-- prettier-ignore-end -->

--- a/test/action.yaml
+++ b/test/action.yaml
@@ -18,7 +18,7 @@ runs:
         fetch-depth: 0
     - name: Setup tools
       ## Installs version of golang found in .go-version
-      uses: open-turo/action-setup-tools@v1
+      uses: open-turo/action-setup-tools@v2
     - name: Authorize
       uses: open-turo/action-git-auth@v2
       with:

--- a/test/action.yaml
+++ b/test/action.yaml
@@ -20,7 +20,7 @@ runs:
       ## Installs version of golang found in .go-version
       uses: open-turo/action-setup-tools@v2
     - name: Authorize
-      uses: open-turo/action-git-auth@v2
+      uses: open-turo/action-git-auth@v3
       with:
         github-personal-access-token: ${{ inputs.github-token }}
     - name: Execute all go tests with coverage in current and all subdirectories


### PR DESCRIPTION
**Description**

This PR aims to update this repo to use workflows closer to those of `actions-node`. 

Main changes:

* Pin `action-docs` version and make it work
* Update several outdated actions
* Use `semantic-release` instead of `go-semantic-release`
* Update `release` workflow
* Update `prerelease` to add comments as well as only trigger based on labels. Apart from this, I updated the action to leverage goreleaser to push docker images, since now prerelease will generate an RC like version when running on pull requests, meaning that we no longer need to manually push tags. In order for this to work, we have to set `create-prerelease` to `true` in a consumer, so that a new tag is created and so that goreleaser has a version to work with. This will create a draft release for every prerelease, but that should be ok, since for non docker releases, goreleaser needs to add the binaries to a release.

**TODOs**

- [x] Address code TODOs
- [x] Update the action CI itself (renovatebot, missing workflows, pre-commit, ...)
- [x] Remove the need for the go-version input
- [x] Ensure the action succeeds when no release is created (go releaser is failing right now)
- [x] The docker image comment is not showing the correct info
- [x] Reword commits

**How has this been tested?**

Internally in some libs shared with the reviewers of this PR

**Changes**

* feat: update release and prelease to our standards
* ci: trigger on main and remove not needed token
* docs: ensure action-docs works correctly
* ci: ignore action-docs output for trim whitespace
* fix(test): update deps
* fix(lint): update deps
* fix(deps): use actions-setup-tools@v2
* build: pin action-docs major version


🚀 PR created with [fotingo](https://github.com/tagoro9/fotingo)
