### PR TITLE
fix: clear git state during prerelease before goreleaser

### DIFF
--- a/prerelease/action.yaml
+++ b/prerelease/action.yaml
@@ -130,6 +130,13 @@ runs:
         username: ${{ inputs.docker-username }}
         password: ${{ inputs.docker-password }}
 
+    - name: Clear git state
+      if: steps.prerelease.outputs.new-release-published == 'true'
+      shell: bash
+      run: |
+        # this resets git state for when also (pre)releasing other artifacts, eg. jvm (gradle.properties gets modified)
+        git reset --hard HEAD
+
     - name: Goreleaser
       uses: goreleaser/goreleaser-action@v6
       if: steps.prerelease.outputs.new-release-published == 'true'


### PR DESCRIPTION
# Changes
Introducing a step to clear git state during the pre-release step, the goreleaser step expects a clean git state, and when (pre)releasing multiple artifacts there is a chance that files may be modified but not committed. The known case right now for when this would happen is during a gradle release, which modifies gradle.properties but does not commit since this is a pre-release.